### PR TITLE
Add 'close' item into the debug window

### DIFF
--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -68,7 +68,7 @@ menu @SReject/JSONForMirc/Log {
   .-
   .Toggle Debug: jsondebug
   .-
-  .Close: close -@ $window
+  .Close: jsondebug off | close -@ $window
 }
 
 

--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -62,11 +62,13 @@ on *:UNLOAD:{
 
 ;; Menu for the debug window
 menu @SReject/JSONForMirc/Log {
-  .Clear: clear -@ @SReject/JSONForMirc/Log
+  .Clear: clear -@ $window
   .-
   .$iif(!$jfm_SaveDebug, $style(2)) Save: jfm_SaveDebug
   .-
   .Toggle Debug: jsondebug
+  .-
+  .Close: close -@ $window
 }
 
 


### PR DESCRIPTION
When someone wanna close it fast and is not familar with the right click into the switchbar, or the swichbar is set off, it would be good to have a right click into the debug window for closing the window.

Also replaced the window name to $window, Tested and working.