### PR TITLE
added k switch for insecure certs

### DIFF
--- a/src/JSON For mIRC.js
+++ b/src/JSON For mIRC.js
@@ -589,7 +589,7 @@
     root.JSONInstance = JSONInstance;
 
     // (slv) Added: 'insecure' bool
-    JSONCreate = function(type, source, parse, insecure) {
+    root.JSONCreate = function(type, source, parse, insecure) {
         var self = new JSONInstance();
         self._state = 'init';
         self._type = (type || 'text').toLowerCase();

--- a/src/JSON For mIRC.js
+++ b/src/JSON For mIRC.js
@@ -137,10 +137,12 @@
         this._parse = parent._parse === false ? false : true;
         this._error = parent._error || false;
         this._input = parent._input;
+        // (slv) Added 'insecure'
         this._http = parent._http || {
             method: 'GET',
             url: '',
-            headers: []
+            headers: [],
+            insecure: false
         };
     }
 
@@ -233,6 +235,13 @@
                         // Create the request, and store it witht he handler
                         request = new ActiveXObject(HTTPObject);
                         this._http.response = request;
+
+                        // (slv) Added: 'Ignore all certificate errors' option
+                        //       Info:  - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms763811(v=vs.85)
+                        //              - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms753798(v=vs.85)
+                        if (this._http.insecure === true) {
+                            request.setOption(2, 13056);
+                        }
                         
                         // initialize the request
                         request.open(this._http.method, this._http.url, false);
@@ -491,7 +500,8 @@
         }
     };
 
-    JSONCreate = function(type, source, parse) {
+    // (slv) Added: 'insecure' bool
+    JSONCreate = function(type, source, parse, insecure) {
         var self = new JSONInstance();
         self._state = 'init';
         self._type = (type || 'text').toLowerCase();
@@ -504,6 +514,7 @@
             }
             self._state = 'http_pending';
             self._http.url = source;
+            self._http.insecure = insecure;
         } else {
             self._state = 'parse_pending';
             self._input = source;

--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -123,7 +123,8 @@ alias JSONOpen {
   }
 
   ;; Local variable declarations
-  var %Switches, %Error, %Com = $false, %Type = text, %HttpOptions = 0, %BVar, %BUnset = $true
+  ; (slv) Added %HttpInsecure
+  var %Switches, %Error, %Com = $false, %Type = text, %HttpOptions = 0, %BVar, %BUnset = $true, %HttpInsecure = 0
 
   ;; Log the /JSONOpen command is being called
   jfm_log -I /JSONOpen $1-
@@ -140,7 +141,8 @@ alias JSONOpen {
   }
 
   ;; Basic switch validation
-  elseif (!$regex(SReject/JSONOpen/switches, %Switches, ^[dbfuUw]*$)) {
+  ; (slv) Added k Switch
+  elseif (!$regex(SReject/JSONOpen/switches, %Switches, ^[dbfuUwk]*$)) {
     %Error = SWITCH_INVALID
   }
   elseif ($regex(%Switches, ([dbfuUw]).*?\1)) {
@@ -207,6 +209,10 @@ alias JSONOpen {
       if (U isincs %Switches) {
         inc %HttpOptions 2
       }
+      ; (slv) Added k Switch
+      if (k isincs %Switches) {
+        %HttpInsecure = -1
+      }
       %Type = http
       bset -t %BVar 1 $2
     }
@@ -224,7 +230,7 @@ alias JSONOpen {
     jfm_ToggleTimers -p
 
     ;; Attempt to create the handler
-    %Error = $jfm_Create(%Com, %Type, %BVar, %HttpOptions)
+    %Error = $jfm_Create(%Com, %Type, %BVar, %HttpOptions, %HttpInsecure)
 
     jfm_ToggleTimers -r
   }
@@ -1808,13 +1814,15 @@ alias -l jfm_GetError {
 alias -l jfm_Create {
 
   ;; Local variable declaration
-  var %Wait = $iif(1 & $4, $true, $false), %Parse = $iif(2 & $4, $false, $true), %Error
+  ; (slv) Added %Insecure
+  var %Wait = $iif(1 & $4, $true, $false), %Parse = $iif(2 & $4, $false, $true), %Insecure = $iif($4 == -1 || $5 == -1, $true, $false), %Error
 
   ;; Log the alias call
   jfm_log -I $!jfm_create( $+ $1 $+ , $+ $2 $+ , $+ $3 $+ , $+ $4 $+ , $+ $5 $+ )
 
   ;; Attempt to create the json handler and if an error occurs retrieve the error, log it and return it
-  if (!$com(SReject/JSONForMirc/JSONEngine, JSONCreate, 1, bstr, $2, &bstr, $3, bool, %Parse, dispatch* $1)) || ($comerr) || (!$com($1)) {
+  ; (slv) Added %Insecure
+  if (!$com(SReject/JSONForMirc/JSONEngine, JSONCreate, 1, bstr, $2, &bstr, $3, bool, %Parse, bool, %Insecure, dispatch* $1)) || ($comerr) || (!$com($1)) {
     %Error = $jfm_GetError
   }
 

--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -77,7 +77,7 @@ menu @SReject/JSONForMirc/Log {
 ;;     -d:  Closes the handler after the script finishes
 ;;     -b:  The input is a bvar
 ;;     -f:  The input is a file
-;;     -k:  Used with -u; Ignore all certificate errors
+;;     -i:  Used with -u; Ignore all certificate errors
 ;;     -u:  The input is from a url
 ;;     -U:  The input is from a url and its data should not be parsed
 ;;     -w:  Used with -u; The handle should wait for /JSONHttpGet to be called to perform the url request
@@ -123,8 +123,8 @@ alias JSONOpen {
   }
 
   ;; Basic switch validation
-  ; (slv) Added k Switch
-  elseif (!$regex(SReject/JSONOpen/switches, %Switches, ^[dbfuUwk]*$)) {
+  ; (slv) Added i Switch
+  elseif (!$regex(SReject/JSONOpen/switches, %Switches, ^[dbfuUwi]*$)) {
     %Error = SWITCH_INVALID
   }
   elseif ($regex(%Switches, ([dbfuUw]).*?\1)) {
@@ -136,8 +136,8 @@ alias JSONOpen {
   elseif (u !isin %Switches) && (w isincs %Switches) {
     %Error = SWITCH_NOT_APPLICABLE:w
   }
-  elseif (u !isin %Switches) && (k isincs %Switches) {
-    %Error = SWITCH_NOT_APPLICABLE:k
+  elseif (u !isin %Switches) && (i isincs %Switches) {
+    %Error = SWITCH_NOT_APPLICABLE:i
   }
 
   ;; Validate handler name input
@@ -195,7 +195,7 @@ alias JSONOpen {
         inc %HttpOptions 2
       }
       ; (slv) Added k Switch
-      if (k isincs %Switches) {
+      if (i isincs %Switches) {
         %HttpInsecure = -1
       }
       %Type = http
@@ -1579,7 +1579,7 @@ alias JSONError {
 ;;         Returns the short version
 alias JSONVersion {
   if ($isid) {
-    var %Ver = 1.1.0002
+    var %Ver = 1.1.0003
     if ($0) {
       return %Ver
     }

--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -96,6 +96,7 @@ menu @SReject/JSONForMirc/Log {
 ;;     -d:  Closes the handler after the script finishes
 ;;     -b:  The input is a bvar
 ;;     -f:  The input is a file
+;;     -k:  Used with -u; Ignore all certificate errors
 ;;     -u:  The input is from a url
 ;;     -U:  The input is from a url and its data should not be parsed
 ;;     -w:  Used with -u; The handle should wait for /JSONHttpGet to be called to perform the url request
@@ -153,6 +154,9 @@ alias JSONOpen {
   }
   elseif (u !isin %Switches) && (w isincs %Switches) {
     %Error = SWITCH_NOT_APPLICABLE:w
+  }
+  elseif (u !isin %Switches) && (k isincs %Switches) {
+    %Error = SWITCH_NOT_APPLICABLE:k
   }
 
   ;; Validate handler name input

--- a/test/JSON for mIRC - Tests.mrc
+++ b/test/JSON for mIRC - Tests.mrc
@@ -21,6 +21,8 @@ alias -l jfm_test {
   var %testnum = 0
   var %err
   var %res
+  var %cert_url
+  var %cert_re
   var %echo = echo 03 -sgi6 $!+([#,$base(%testNum,10,10,3),])
 
   jsonshutdown
@@ -180,10 +182,10 @@ alias -l jfm_test {
   }
   $(%echo,2) /JSONOpen -w : Passed Check: SWITCH_NOT_APPLICABLE
 
-  ; (slv) Added k switch
-  ;; test to make sure /JSONOpen raises "SWITCH_NOT_APPLICABLE" when -k is specified without -u/-U
+  ; (slv) Added i switch
+  ;; test to make sure /JSONOpen raises "SWITCH_NOT_APPLICABLE" when -i is specified without -u/-U
   inc %testnum
-  JSONOpen -k jfm_test "a"
+  JSONOpen -i jfm_test "a"
   %err = $JSONError
   if (%err == $null) {
     return %testnum /JSONOpen -uU : Failed to report error (SWITCH_NOT_APPLICABLE)
@@ -191,7 +193,7 @@ alias -l jfm_test {
   if (SWITCH_NOT_APPLICABLE:* !iswm %err) {
     return %testnum /JSONOpen -uU : Reported incorrect error: $v2
   }
-  $(%echo,2) /JSONOpen -k : Passed Check: SWITCH_NOT_APPLICABLE
+  $(%echo,2) /JSONOpen -i : Passed Check: SWITCH_NOT_APPLICABLE
 
 
   ;; test to make sure /JSONOpen raises "PARAMETER_MISSING" if -b is specified
@@ -1197,7 +1199,7 @@ alias -l jfm_test {
   ;;                              ;;
   ;;==============================;;
 
-  ;; (slv) Added Test: Attempt to use invalid SSL cert with/without k switch
+  ;; (slv) Added Test: Attempt to use invalid SSL cert with/without i switch
   %cert_url = https://self-signed.badssl.com
   %cert_re = /^The certificate authority is invalid or incorrect/
   inc %testnum
@@ -1208,11 +1210,11 @@ alias -l jfm_test {
   $(%echo,2) /JSONOpen -u %cert_url : Passed Check
   JSONClose jfm_test
   inc %testnum
-  JSONOpen -uk jfm_test %cert_url
+  JSONOpen -ui jfm_test %cert_url
   if ($regex($JSONError,%cert_re)) {
-    return %testnum /JSONOpen -uk %cert_url : Request reported error: $v2
+    return %testnum /JSONOpen -ui %cert_url : Request reported error: $v2
   }
-  $(%echo,2) /JSONOpen -uk %cert_url : Request succeeded
+  $(%echo,2) /JSONOpen -ui %cert_url : Request succeeded
   JSONClose jfm_test
 
   ;; Attempt to retrieve data from a remote source
@@ -1220,9 +1222,7 @@ alias -l jfm_test {
   JSONOpen -u jfm_test http://echo.jsontest.com/key/value
   if ($null !== $JSONError) {
     if ($JSONError == INVALID_JSON) {
-      echo -ast There might be an issue with jsontest.com : $v2
-      echo -ast Possible reason could be 'Over Quota', halting further tests...
-      halt
+      return %testnum /JSONOpen -u : Request reported error: $v2 WARNING: possible issue with jsontest.com ('Over Quota')
     }
     return %testnum /JSONOpen -u : Request reported error: $v2
   }


### PR DESCRIPTION
Hi @SReject,

Thanks for JFM, i've used it in 2 scripts now and works nicely. I also like how in the new versions the JS part is formatted in seperate file.

For an API on localhost with selfsigned cert I got a (expected) cert error "The certificate authority is invalid or incorrect".
I could not find an option to disable cert checking so a I added a "k" switch to JSONOpen (like curl -k).

The Tests script passed and I've added tests for -k without -u" switch and 2 for JSONOpen and a known bad cert with/without "-k".
