### PR TITLE
Add a check for the .js file on load

### DIFF
--- a/src/JSON For mIRC.mrc
+++ b/src/JSON For mIRC.mrc
@@ -1,6 +1,13 @@
 ;; Check to make sure mIRC/AdiIRC is of an applicable version
 on *:LOAD:{
 
+  ;; Check for 'JSON For Mirc.js' file because it's required
+  var %JsFile = $scriptdirJSON For Mirc.js
+  if (!$file(%JsFile)) {
+    echo -ag [JSON For mIRC] The 'JSON For Mirc.js' file is required to work, that file is already included in the .zip file, place it in the same folder as you did for the .mrc file
+    .unload -rs $qt($script)
+  }
+  
   ;; Adiirc check
   if ($~adiircexe) {
     if ($version < 3.0) {


### PR DESCRIPTION
Some users are trying to load the .mrc file without placing the .js file in the same folder, a check about it might help to understand why the code is not working.